### PR TITLE
Swift Concurrency: PlayolaErrorReporter

### DIFF
--- a/Sources/PlayolaPlayer/Player/AudioNormalizationCalculator.swift
+++ b/Sources/PlayolaPlayer/Player/AudioNormalizationCalculator.swift
@@ -34,13 +34,11 @@ struct AudioNormalizationCalculator {
           calculator.amplitude = calculator.getAmplitude(samples)
         } catch {
           // Report error on main thread
-          await MainActor.run {
-            PlayolaErrorReporter.shared.reportError(
-              error,
-              context:
-                "Failed to get audio samples for normalization | File: \(file.url.lastPathComponent) | Format: \(file.processingFormat.description) | Length: \(file.length)",
-              level: .warning)
-          }
+          await PlayolaErrorReporter.shared.reportError(
+            error,
+            context:
+              "Failed to get audio samples for normalization | File: \(file.url.lastPathComponent) | Format: \(file.processingFormat.description) | Length: \(file.length)",
+            level: .warning)
         }
         continuation.resume(returning: calculator)
       }
@@ -55,8 +53,8 @@ struct AudioNormalizationCalculator {
       self.amplitude = getAmplitude(samples)
     } catch {
       // Replace print with proper error reporting
-      Task { @MainActor in
-        PlayolaErrorReporter.shared.reportError(
+      Task {
+        await PlayolaErrorReporter.shared.reportError(
           error,
           context:
             "Failed to get audio samples for normalization | File: \(file.url.lastPathComponent) | Format: \(file.processingFormat.description) | Length: \(file.length)",
@@ -84,8 +82,8 @@ struct AudioNormalizationCalculator {
         pcmFormat: file.processingFormat, frameCapacity: AVAudioFrameCount(file.length))
     else {
       let detailedError = AudioError.bufferConversion
-      Task { @MainActor in
-        PlayolaErrorReporter.shared.reportError(
+      Task {
+        await PlayolaErrorReporter.shared.reportError(
           detailedError,
           context:
             "Failed to create PCM buffer | File format: \(file.processingFormat.description) | Frame capacity: \(file.length)",
@@ -98,8 +96,8 @@ struct AudioNormalizationCalculator {
       try file.read(into: buffer)
     } catch {
       // Enhance the error with context before throwing
-      Task { @MainActor in
-        PlayolaErrorReporter.shared.reportError(
+      Task {
+        await PlayolaErrorReporter.shared.reportError(
           error,
           context:
             "Failed to read audio file into buffer | File: \(file.url.lastPathComponent) | Format: \(file.processingFormat.description)",
@@ -110,8 +108,8 @@ struct AudioNormalizationCalculator {
 
     guard let channelData = buffer.floatChannelData?.pointee else {
       let error = AudioError.bufferConversion
-      Task { @MainActor in
-        PlayolaErrorReporter.shared.reportError(
+      Task {
+        await PlayolaErrorReporter.shared.reportError(
           error,
           context:
             "Failed to get float channel data from buffer | Buffer length: \(buffer.frameLength)",

--- a/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
@@ -179,7 +179,9 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
       let result = try await downloader.download(from: url, to: destinationURL)
       return result.localURL
     } catch {
-      await errorReporter.reportError(error)
+      Task {
+        await errorReporter.reportError(error)
+      }
       throw error
     }
   }
@@ -215,7 +217,9 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
       case .completed(let result):
         return result.localURL
       case .failed(let error):
-        await errorReporter.reportError(error)
+        Task {
+          await errorReporter.reportError(error)
+        }
         throw error
       }
     }

--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -55,7 +55,7 @@ open class PlayolaMainMixer: NSObject {
           format: TapProperties.default.format)
       } catch {
         Task { @MainActor in
-          errorReporter.reportError(
+          await errorReporter.reportError(
             error,
             context: "Failed to connect mixer nodes: \(error.localizedDescription)",
             level: .critical)
@@ -73,7 +73,7 @@ open class PlayolaMainMixer: NSObject {
           block: self.onTap(_:_:))
       } catch {
         Task { @MainActor in
-          errorReporter.reportError(
+          await errorReporter.reportError(
             error,
             context: "Failed to install tap on mixer node: \(error.localizedDescription)",
             level: .critical)
@@ -82,7 +82,7 @@ open class PlayolaMainMixer: NSObject {
       }
     } catch {
       Task { @MainActor in
-        errorReporter.reportError(
+        await errorReporter.reportError(
           error,
           context: "Critical failure initializing PlayolaMainMixer: \(error.localizedDescription)",
           level: .critical)
@@ -116,7 +116,7 @@ open class PlayolaMainMixer: NSObject {
       } catch {
         // This is not a critical error, just log it
         Task { @MainActor in
-          errorReporter.reportError(
+          await errorReporter.reportError(
             error,
             context: "Non-critical: Failed to deactivate audio session before configuration",
             level: .warning)
@@ -137,7 +137,7 @@ open class PlayolaMainMixer: NSObject {
         Task { @MainActor in
           let deviceName = UIDevice.current.name
           let systemVersion = UIDevice.current.systemVersion
-          errorReporter.reportError(
+          await errorReporter.reportError(
             error,
             context:
               "Failed to set audio session category | Device: \(deviceName) | iOS: \(systemVersion)",
@@ -157,7 +157,7 @@ open class PlayolaMainMixer: NSObject {
           let currentRoute = session.currentRoute.outputs.map { $0.portName }.joined(
             separator: ", ")
 
-          errorReporter.reportError(
+          await errorReporter.reportError(
             error,
             context:
               "Failed to activate audio session | Device: \(deviceName) | iOS: \(systemVersion) | Route: \(currentRoute)",
@@ -167,7 +167,7 @@ open class PlayolaMainMixer: NSObject {
       }
     } catch {
       Task { @MainActor in
-        errorReporter.reportError(
+        await errorReporter.reportError(
           error,
           context: "Critical error configuring audio session: \(error.localizedDescription)",
           level: .critical)
@@ -188,7 +188,7 @@ open class PlayolaMainMixer: NSObject {
       os_log("Audio session deactivated", log: PlayolaMainMixer.logger, type: .info)
     } catch {
       Task { @MainActor in
-        errorReporter.reportError(
+        await errorReporter.reportError(
           error, context: "Failed to deactivate audio session", level: .warning)
       }
     }
@@ -231,9 +231,11 @@ extension PlayolaMainMixer {
     // If we get here, all retries failed
     if let error = lastError {
 
-      errorReporter.reportError(
-        error, context: "Failed to start audio engine after \(maxRetries) attempts",
-        level: .critical)
+      Task {
+        await errorReporter.reportError(
+          error, context: "Failed to start audio engine after \(maxRetries) attempts",
+          level: .critical)
+      }
       throw error
     }
   }


### PR DESCRIPTION
This pull request refactors error reporting throughout the PlayolaPlayer codebase to use Swift's new `actor` model for thread-safe, asynchronous error handling. The main error reporting class, `PlayolaErrorReporter`, is now an actor, and all calls to its methods are updated to use async/await patterns. This change removes explicit use of background queues and ensures correct concurrency, improving safety and reliability in error reporting.

Key changes:

### Error Reporter Refactor

* Converted `PlayolaErrorReporter` from a `@MainActor` class with manual dispatch queue management to an `actor`, making all its methods thread-safe and asynchronous. The reporting queue and related manual concurrency code were removed. (`Sources/PlayolaPlayer/ErrorHandling/PlayolaErrorReporter.swift`) [[1]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L76-R76) [[2]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L97-L99)
* Updated the `reportError` and related methods to be `async`, and updated internal deduplication logic to be async as well. (`Sources/PlayolaPlayer/ErrorHandling/PlayolaErrorReporter.swift`) [[1]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L122-R118) [[2]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L143-R153) [[3]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L186-R179) [[4]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L198-R191) [[5]](diffhunk://#diff-bf844ede929c06d8c09bb18eab01da55eb20858e5ba3c00586f858cd52e19c42L242-R235)

### Error Reporting Call Site Updates

* Updated all error reporting calls throughout the codebase to use `await` and async tasks, removing explicit `@MainActor` annotations and ensuring errors are reported safely from any thread. This includes changes in `AudioNormalizationCalculator`, `FileDownloadManagerAsync`, `ListeningSessionReporter`, and `PlayolaMainMixer`. [[1]](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9L37-L44) [[2]](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9L58-R57) [[3]](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9L87-R86) [[4]](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9L101-R100) [[5]](diffhunk://#diff-b653964dfe5fb76df55dccce3a2803a1bd97cae2562817f9b3c622c9e0c463b9L113-R112) [[6]](diffhunk://#diff-e61b5d703104bf73c979008edc1c30af42d1034e0d1ce9965a2456498dade00eR182-R184) [[7]](diffhunk://#diff-e61b5d703104bf73c979008edc1c30af42d1034e0d1ce9965a2456498dade00eR220-R222) [[8]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L81-R106) [[9]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L114-R120) [[10]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L133-R152) [[11]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L170-R184) [[12]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L183-R199) [[13]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L192-R216) [[14]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L219-R243) [[15]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L282-R308) [[16]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL58-R58) [[17]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL76-R76) [[18]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL85-R85) [[19]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL119-R119) [[20]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL140-R140) [[21]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL160-R160) [[22]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL170-R170)

### Extension and Helper Updates

* Updated the `Error` extension to use the new async error reporting method without forcing execution on the main actor. (`Sources/PlayolaPlayer/ErrorHandling/PlayolaErrorReporter.swift`)

These changes modernize error handling, leverage Swift's concurrency features, and reduce the risk of threading bugs in error reporting.