### PR TITLE
OSX Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
   name: "PlayolaPlayer",
   platforms: [
-    .iOS(.v17)
+    .iOS(.v17),
+    .macOS(.v14),
   ],
   products: [
     // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Sources/PlayolaPlayer/Player/AudioSessionManager.swift
+++ b/Sources/PlayolaPlayer/Player/AudioSessionManager.swift
@@ -1,0 +1,102 @@
+//
+//  AudioSessionManager.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 8/8/25.
+//
+
+import AVFoundation
+import Foundation
+
+/// Protocol for managing audio session configuration across platforms
+protocol AudioSessionManaging {
+  func configureForPlayback() async throws
+  func activate() async throws
+  func deactivate() async throws
+  var isConfigured: Bool { get }
+}
+
+#if os(iOS)
+  /// iOS implementation using AVAudioSession
+  class AudioSessionManager: AudioSessionManaging {
+    private var _isConfigured = false
+    private let errorReporter: PlayolaErrorReporter
+
+    var isConfigured: Bool { _isConfigured }
+
+    init(errorReporter: PlayolaErrorReporter = .shared) {
+      self.errorReporter = errorReporter
+    }
+
+    func configureForPlayback() async throws {
+      let session = AVAudioSession.sharedInstance()
+
+      // First deactivate with appropriate options to reset state
+      do {
+        try session.setActive(false, options: .notifyOthersOnDeactivation)
+      } catch {
+        // This is not a critical error, just log it
+        await errorReporter.reportError(
+          error,
+          context: "Non-critical error deactivating audio session before configuration",
+          level: .warning
+        )
+      }
+
+      // Configure for playback category
+      try session.setCategory(
+        .playback,
+        mode: .default,
+        options: [.allowBluetooth, .allowBluetoothA2DP, .allowAirPlay]
+      )
+
+      _isConfigured = true
+    }
+
+    func activate() async throws {
+      if !_isConfigured {
+        try await configureForPlayback()
+      }
+
+      let session = AVAudioSession.sharedInstance()
+      try session.setActive(true)
+    }
+
+    func deactivate() async throws {
+      guard _isConfigured else { return }
+
+      let session = AVAudioSession.sharedInstance()
+      try session.setActive(false, options: .notifyOthersOnDeactivation)
+      _isConfigured = false
+    }
+  }
+#endif
+
+#if os(macOS)
+  /// macOS implementation - audio session management is handled automatically
+  class AudioSessionManager: AudioSessionManaging {
+    private var _isConfigured = false
+
+    var isConfigured: Bool { _isConfigured }
+
+    init(errorReporter: PlayolaErrorReporter = .shared) {
+      // errorReporter not needed on macOS but kept for API compatibility
+    }
+
+    func configureForPlayback() async throws {
+      // On macOS, audio configuration is handled automatically by the system
+      // No explicit session configuration needed
+      _isConfigured = true
+    }
+
+    func activate() async throws {
+      // On macOS, audio activation is handled automatically
+      _isConfigured = true
+    }
+
+    func deactivate() async throws {
+      // On macOS, audio deactivation is handled automatically
+      _isConfigured = false
+    }
+  }
+#endif

--- a/Sources/PlayolaPlayer/Player/DeviceInfoProvider.swift
+++ b/Sources/PlayolaPlayer/Player/DeviceInfoProvider.swift
@@ -1,0 +1,57 @@
+//
+//  DeviceInfoProvider.swift
+//  PlayolaPlayer
+//
+//  Created by Brian D Keane on 8/8/25.
+//
+
+import Foundation
+
+#if os(iOS)
+  import UIKit
+#endif
+
+/// Provides cross-platform device information
+public struct DeviceInfoProvider {
+
+  public static var deviceName: String {
+    #if os(iOS)
+      return UIDevice.current.name
+    #elseif os(macOS)
+      return Host.current().localizedName ?? "Mac"
+    #endif
+  }
+
+  public static var systemVersion: String {
+    #if os(iOS)
+      return UIDevice.current.systemVersion
+    #elseif os(macOS)
+      let version = ProcessInfo.processInfo.operatingSystemVersion
+      return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+    #endif
+  }
+
+  public static var identifierForVendor: UUID? {
+    #if os(iOS)
+      return UIDevice.current.identifierForVendor
+    #elseif os(macOS)
+      return getOrCreateVendorIdentifier()
+    #endif
+  }
+
+  #if os(macOS)
+    private static let vendorIdentifierKey = "PlayolaPlayer.VendorIdentifier"
+
+    private static func getOrCreateVendorIdentifier() -> UUID? {
+      if let uuidString = UserDefaults.standard.string(forKey: vendorIdentifierKey),
+        let uuid = UUID(uuidString: uuidString)
+      {
+        return uuid
+      }
+
+      let newUUID = UUID()
+      UserDefaults.standard.set(newUUID.uuidString, forKey: vendorIdentifierKey)
+      return newUUID
+    }
+  #endif
+}

--- a/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
+++ b/Sources/PlayolaPlayer/Player/FileDownloadManagerAsync.swift
@@ -137,11 +137,23 @@ public class FileDownloadManagerAsync: FileDownloadManaging {
   /// File manager for cache operations
   private let fileManager = FileManager.default
 
-  /// Cache directory URL
-  private var cacheDirectoryURL: URL {
-    let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
-    return documentsPath.appendingPathComponent(Self.subfolderName)
-  }
+  #if os(iOS)
+    /// Cache directory URL
+    private var cacheDirectoryURL: URL {
+      let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+      return documentsPath.appendingPathComponent(Self.subfolderName)
+    }
+  #endif
+
+  #if os(macOS)
+    /// Cache directory URL
+    private var cacheDirectoryURL: URL {
+      let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+        .first!
+      let bundleID = Bundle.main.bundleIdentifier ?? "fm.playola.PlayolaPlayer"
+      return appSupport.appendingPathComponent(bundleID).appendingPathComponent(Self.subfolderName)
+    }
+  #endif
 
   public init() {
     createCacheDirectoryIfNeeded()

--- a/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
+++ b/Sources/PlayolaPlayer/Player/ListeningSessionReporter.swift
@@ -8,7 +8,10 @@
 import AVFoundation
 import Combine
 import Foundation
-import UIKit
+
+#if os(iOS)
+  import UIKit
+#endif
 
 /// Errors specific to the listening session reporting
 public enum ListeningSessionError: Error, LocalizedError {
@@ -44,7 +47,7 @@ public class ListeningSessionReporter {
   }
 
   var deviceId: String? {
-    return UIDevice.current.identifierForVendor?.uuidString
+    return DeviceInfoProvider.identifierForVendor?.uuidString
   }
   var timer: Timer?
   let basicToken = "aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx"  // TODO: De-hard-code this

--- a/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaMainMixer.swift
@@ -7,8 +7,11 @@
 
 import AVFoundation
 import Foundation
-import UIKit
 import os.log
+
+#if os(iOS)
+  import UIKit
+#endif
 
 public protocol PlayolaMainMixerDelegate {
   func player(_ mainMixer: PlayolaMainMixer, didPlayBuffer: AVAudioPCMBuffer)
@@ -98,8 +101,8 @@ open class PlayolaMainMixer: NSObject {
         )
       } catch {
         Task { @MainActor in
-          let deviceName = UIDevice.current.name
-          let systemVersion = UIDevice.current.systemVersion
+          let deviceName = DeviceInfoProvider.deviceName
+          let systemVersion = DeviceInfoProvider.systemVersion
           await errorReporter.reportError(
             error,
             context:
@@ -115,8 +118,8 @@ open class PlayolaMainMixer: NSObject {
         os_log("Audio session successfully configured", log: PlayolaMainMixer.logger, type: .info)
       } catch {
         Task { @MainActor in
-          let deviceName = UIDevice.current.name
-          let systemVersion = UIDevice.current.systemVersion
+          let deviceName = DeviceInfoProvider.deviceName
+          let systemVersion = DeviceInfoProvider.systemVersion
           let currentRoute = session.currentRoute.outputs.map { $0.portName }.joined(
             separator: ", ")
 

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -135,16 +135,18 @@ final public class PlayolaStationPlayer: ObservableObject {
     self.authProvider = nil
     self.listeningSessionReporter = ListeningSessionReporter(stationPlayer: self, authProvider: nil)
 
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(handleAudioSessionInterruption(_:)),
-      name: AVAudioSession.interruptionNotification,
-      object: nil
-    )
+    #if os(iOS)
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(handleAudioSessionInterruption(_:)),
+        name: AVAudioSession.interruptionNotification,
+        object: nil
+      )
 
-    NotificationCenter.default.addObserver(
-      self, selector: #selector(handleAudioRouteChange(_:)),
-      name: AVAudioSession.routeChangeNotification, object: nil)
+      NotificationCenter.default.addObserver(
+        self, selector: #selector(handleAudioRouteChange(_:)),
+        name: AVAudioSession.routeChangeNotification, object: nil)
+    #endif
   }
 
   private static let logger = OSLog(
@@ -535,73 +537,75 @@ final public class PlayolaStationPlayer: ObservableObject {
     os_log("✅ STOP completed", log: PlayolaStationPlayer.logger, type: .info)
   }
 
-  /// Handle audio route changes such as connecting/disconnecting headphones
-  @objc public func handleAudioRouteChange(_ notification: Notification) {
-    guard let userInfo = notification.userInfo,
-      let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
-      let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
-    else {
-      return
-    }
-
-    // Check if the audio route changed
-    switch reason {
-    case .newDeviceAvailable:
-      // New device (like headphones) was connected
-      os_log("New audio route device available", log: PlayolaStationPlayer.logger, type: .info)
-
-    case .oldDeviceUnavailable:
-      // Old device (like headphones) was disconnected
-      // You might want to pause playback here
-      os_log("Audio route device disconnected", log: PlayolaStationPlayer.logger, type: .info)
-
-    default:
-      // Handle other route changes if needed
-      os_log(
-        "Audio route changed for reason: %d", log: PlayolaStationPlayer.logger, type: .info,
-        reasonValue)
-    }
-  }
-
-  /// Handle audio session interruptions such as phone calls
-  @objc public func handleAudioSessionInterruption(_ notification: Notification) {
-    guard let userInfo = notification.userInfo,
-      let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
-      let type = AVAudioSession.InterruptionType(rawValue: typeValue)
-    else {
-      return
-    }
-
-    switch type {
-    case .began:
-      // Audio session was interrupted - might need to pause playback
-      os_log("Audio session interrupted", log: PlayolaStationPlayer.logger, type: .info)
-      self.interruptedStationId = stationId
-      stop()
-
-    case .ended:
-      // Interruption ended - might need to resume playback
-      guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+  #if os(iOS)
+    /// Handle audio route changes such as connecting/disconnecting headphones
+    @objc public func handleAudioRouteChange(_ notification: Notification) {
+      guard let userInfo = notification.userInfo,
+        let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+        let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
+      else {
         return
       }
-      let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
 
-      if options.contains(.shouldResume) {
-        // The system indicates that we can resume audio
-        if let interruptedStationId {
-          Task { @MainActor [interruptedStationId] in
-            try? await self.play(stationId: interruptedStationId)
-          }
-          self.interruptedStationId = nil
-        }
+      // Check if the audio route changed
+      switch reason {
+      case .newDeviceAvailable:
+        // New device (like headphones) was connected
+        os_log("New audio route device available", log: PlayolaStationPlayer.logger, type: .info)
+
+      case .oldDeviceUnavailable:
+        // Old device (like headphones) was disconnected
+        // You might want to pause playback here
+        os_log("Audio route device disconnected", log: PlayolaStationPlayer.logger, type: .info)
+
+      default:
+        // Handle other route changes if needed
+        os_log(
+          "Audio route changed for reason: %d", log: PlayolaStationPlayer.logger, type: .info,
+          reasonValue)
+      }
+    }
+
+    /// Handle audio session interruptions such as phone calls
+    @objc public func handleAudioSessionInterruption(_ notification: Notification) {
+      guard let userInfo = notification.userInfo,
+        let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+        let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+      else {
+        return
       }
 
-    @unknown default:
-      os_log(
-        "Unknown audio session interruption type: %d", log: PlayolaStationPlayer.logger,
-        type: .error, typeValue)
+      switch type {
+      case .began:
+        // Audio session was interrupted - might need to pause playback
+        os_log("Audio session interrupted", log: PlayolaStationPlayer.logger, type: .info)
+        self.interruptedStationId = stationId
+        stop()
+
+      case .ended:
+        // Interruption ended - might need to resume playback
+        guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else {
+          return
+        }
+        let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+
+        if options.contains(.shouldResume) {
+          // The system indicates that we can resume audio
+          if let interruptedStationId {
+            Task { @MainActor [interruptedStationId] in
+              try? await self.play(stationId: interruptedStationId)
+            }
+            self.interruptedStationId = nil
+          }
+        }
+
+      @unknown default:
+        os_log(
+          "Unknown audio session interruption type: %d", log: PlayolaStationPlayer.logger,
+          type: .error, typeValue)
+      }
     }
-  }
+  #endif
 
   deinit {
     // Ensure all resources are properly cleaned up

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -608,7 +608,6 @@ final public class PlayolaStationPlayer: ObservableObject {
   #endif
 
   deinit {
-    // Ensure all resources are properly cleaned up
     fileDownloadManager.cancelAllDownloads()
   }
 }
@@ -645,7 +644,6 @@ extension PlayolaStationPlayer: SpinPlayerDelegate {
     atTime time: TimeInterval,
     withBuffer buffer: AVAudioPCMBuffer
   ) {
-    // No error handling needed here
   }
 
   public func player(_ player: SpinPlayer, didChangeState state: SpinPlayer.State) {


### PR DESCRIPTION
This pull request introduces cross-platform (iOS and macOS) support to the PlayolaPlayer package by refactoring platform-specific code, abstracting device and audio session handling, and updating file management and playback logic. The changes ensure that core functionalities work seamlessly on both platforms, with appropriate conditional compilation and platform abstractions.

**Cross-platform abstractions and platform-specific logic:**

* Added a new `DeviceInfoProvider` struct to provide device name, system version, and persistent vendor identifier in a cross-platform way, abstracting away platform differences.
* Introduced an `AudioSessionManager` protocol and platform-specific implementations to manage audio session configuration for both iOS (using `AVAudioSession`) and macOS (no-op, as macOS handles audio sessions automatically). Updated `PlayolaMainMixer` to use this abstraction. [[1]](diffhunk://#diff-de51d8f02a989e72ef4521dfa63e6fdfec03597f72fe33f11cd28a0064ecc4e8R1-R102) [[2]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL39-R49) [[3]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL70-L153)

**File and cache management:**

* Updated `FileDownloadManagerAsync` to use the appropriate cache directory for each platform: `Documents` on iOS and `Application Support` on macOS, including bundle ID for macOS.

**Playback and timing improvements:**

* Refactored `SpinPlayer` to use `CADisplayLink` for fade animations on iOS and a `Timer` on macOS, ensuring smooth fade operations on both platforms. [[1]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L11-R16) [[2]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L43-R50) [[3]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6R282-R288) [[4]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L656-R686) [[5]](diffhunk://#diff-13d941cfbe9cdff0d0ff0dc42334234cefdc61f053764c0f1aadaa35e5c0c3e6L704-R729)

**Platform-specific code guards and event handling:**

* Wrapped iOS-only imports and event observers (such as `NotificationCenter` for audio interruptions and route changes) in `#if os(iOS)` guards to prevent macOS build issues and ensure correct event handling per platform. [[1]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR138) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR149) [[3]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR540) [[4]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR608) [[5]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013R11-R14) [[6]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL10-R15)

**Device information usage:**

* Updated usage of device identifier and system info in `ListeningSessionReporter` and error reporting to use the new `DeviceInfoProvider` abstraction, replacing direct `UIDevice` references. [[1]](diffhunk://#diff-3f80dbf72f23400b5a75fa5b1a47d81cba89b3011a208e508ef62a6460cf8013L47-R50) [[2]](diffhunk://#diff-9b51590771d39728406d2fa6c2a162a58d2bf4259e7663ec44d0cc699657cf7fL70-L153)

**Platform support declaration:**

* Added `.macOS(.v14)` to the supported platforms in `Package.swift`, officially enabling macOS support for the package.