### PR TITLE
Add Play atDate

### DIFF
--- a/PlayolaPlayerExample/PlayolaPlayerExample/ContentView.swift
+++ b/PlayolaPlayerExample/PlayolaPlayerExample/ContentView.swift
@@ -135,7 +135,49 @@ struct ContentView: View {
           }
           .frame(height: 80)
 
-          // Playback controls
+          // Offset playback controls
+          VStack(spacing: 20) {
+            // Time offset buttons
+            Text("Play from different times:")
+              .font(.caption)
+              .foregroundColor(.white.opacity(0.6))
+
+            HStack(spacing: 15) {
+              Button("5min ago") {
+                playWithOffset(-300)  // 5 minutes ago
+              }
+              .buttonStyle(OffsetButtonStyle())
+
+              Button("1min ago") {
+                playWithOffset(-60)  // 1 minute ago
+              }
+              .buttonStyle(OffsetButtonStyle())
+
+              Button("10sec ago") {
+                playWithOffset(-10)  // 10 seconds ago
+              }
+              .buttonStyle(OffsetButtonStyle())
+            }
+
+            HStack(spacing: 15) {
+              Button("10sec future") {
+                playWithOffset(10)  // 10 seconds from now
+              }
+              .buttonStyle(OffsetButtonStyle())
+
+              Button("1min future") {
+                playWithOffset(60)  // 1 minute from now
+              }
+              .buttonStyle(OffsetButtonStyle())
+
+              Button("5min future") {
+                playWithOffset(300)  // 5 minutes from now
+              }
+              .buttonStyle(OffsetButtonStyle())
+            }
+          }
+
+          // Main playback controls
           HStack(spacing: 40) {
             // Station picker
             Button(action: { showingStationPicker.toggle() }) {
@@ -144,7 +186,7 @@ struct ContentView: View {
                 .foregroundColor(.white.opacity(0.8))
             }
 
-            // Play/Stop button
+            // Play/Stop button (current time)
             Button(action: playOrPause) {
               ZStack {
                 Circle()
@@ -330,6 +372,43 @@ func playOrPause() {
         print("Failed to start playback: \(error)")
       }
     }
+  }
+}
+
+func playWithOffset(_ offsetSeconds: TimeInterval) {
+  Task {
+    // Always stop current playback first
+    await PlayolaStationPlayer.shared.stop()
+
+    // Calculate the target date
+    let atDate = Date().addingTimeInterval(offsetSeconds)
+
+    do {
+      try await PlayolaStationPlayer.shared.play(
+        stationId: "9d79fd38-1940-4312-8fe8-3b9b50d49c6c",
+        atDate: atDate
+      )
+      print("Started playback with offset: \(offsetSeconds) seconds (at: \(atDate))")
+    } catch {
+      print("Failed to start offset playback: \(error)")
+    }
+  }
+}
+
+// Custom button style for offset buttons
+struct OffsetButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.caption)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 8)
+      .background(
+        RoundedRectangle(cornerRadius: 16)
+          .fill(Color.white.opacity(configuration.isPressed ? 0.3 : 0.2))
+      )
+      .foregroundColor(.white)
+      .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+      .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
   }
 }
 

--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -15,7 +15,7 @@ public struct Schedule: Sendable {
   public let dateProvider: DateProviderProtocol
   private let timerProvider: TimerProvider
 
-  public var nowPlaying: Spin? {
+  public func nowPlaying() -> Spin? {
     let now = dateProvider.now()
     return
       spins
@@ -44,7 +44,7 @@ public struct Schedule: Sendable {
     self.timerProvider = timerProvider
   }
 
-  public var current: [Spin] {
+  public func current() -> [Spin] {
     let now = dateProvider.now()
     return spins.filter({ $0.endtime > now }).sorted { $0.airtime < $1.airtime }
   }

--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -51,7 +51,7 @@ public struct Schedule: Sendable {
 
   private func adjustedSpins(offsetTimeInterval: TimeInterval? = nil) -> [Spin] {
     guard let offsetTimeInterval else { return spins }
-    return spins.map { $0.withOffset(offsetTimeInterval) }
+    return spins.map { $0.withOffset(-offsetTimeInterval) }
   }
 }
 

--- a/Sources/PlayolaPlayer/Models/Schedule.swift
+++ b/Sources/PlayolaPlayer/Models/Schedule.swift
@@ -15,16 +15,11 @@ public struct Schedule: Sendable {
   public let dateProvider: DateProviderProtocol
   private let timerProvider: TimerProvider
 
-  public func nowPlaying() -> Spin? {
-    let now = dateProvider.now()
-    return
-      spins
-      .filter { spin in
-        // A spin is playing if current time is between its airtime and endtime
-        spin.airtime <= now && spin.endtime > now
-      }
-      .sorted { $0.airtime > $1.airtime }  // Sort by airtime descending
-      .first
+  public func current(offsetTimeInterval: TimeInterval? = nil) -> [Spin] {
+    let adjustedSpins = adjustedSpins(offsetTimeInterval: offsetTimeInterval)
+    return adjustedSpins.filter({ $0.endtime > dateProvider.now() }).sorted {
+      $0.airtime < $1.airtime
+    }
   }
 
   public init(
@@ -44,9 +39,19 @@ public struct Schedule: Sendable {
     self.timerProvider = timerProvider
   }
 
-  public func current() -> [Spin] {
+  public func nowPlaying(offsetTimeInterval: TimeInterval? = nil) -> Spin? {
+    let adjustedSpins = adjustedSpins(offsetTimeInterval: offsetTimeInterval)
     let now = dateProvider.now()
-    return spins.filter({ $0.endtime > now }).sorted { $0.airtime < $1.airtime }
+    return
+      adjustedSpins
+      .filter { $0.airtime <= now && $0.endtime > now }
+      .sorted { $0.airtime > $1.airtime }
+      .first
+  }
+
+  private func adjustedSpins(offsetTimeInterval: TimeInterval? = nil) -> [Spin] {
+    guard let offsetTimeInterval else { return spins }
+    return spins.map { $0.withOffset(offsetTimeInterval) }
   }
 }
 

--- a/Sources/PlayolaPlayer/Models/Spin.swift
+++ b/Sources/PlayolaPlayer/Models/Spin.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-public struct Fade: Codable, Sendable {
+public struct Fade: Codable, Sendable, Equatable {
   public let atMS: Int
   public let toVolume: Float
 
@@ -88,6 +88,30 @@ public struct Spin: Codable, Sendable {
   /// Whether this spin is currently playing, based on current time compared to airtime and endtime
   public var isPlaying: Bool {
     return airtime <= dateProvider.now() && dateProvider.now() <= endtime
+  }
+
+  /// Creates a new Spin with the airtime adjusted by the given offset.
+  /// All other properties remain unchanged from the original spin.
+  ///
+  /// - Parameter offset: The time interval to add to the airtime (positive for future, negative for past)
+  /// - Returns: A new Spin instance with adjusted airtime
+  public func withOffset(_ offset: TimeInterval) -> Spin {
+    var newSpin = Spin(
+      id: id,
+      stationId: stationId,
+      airtime: airtime.addingTimeInterval(offset),
+      startingVolume: startingVolume,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      audioBlock: audioBlock,
+      fades: fades,
+      relatedTexts: relatedTexts
+    )
+
+    // Preserve the dateProvider
+    newSpin.dateProvider = dateProvider
+
+    return newSpin
   }
 
   private enum CodingKeys: String, CodingKey {

--- a/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
+++ b/Sources/PlayolaPlayer/Player/PlayolaStationPlayer.swift
@@ -305,10 +305,10 @@ final public class PlayolaStationPlayer: ObservableObject {
       // Log how many spins are in the updated schedule
       os_log(
         "Retrieved schedule: %d total, %d current", log: PlayolaStationPlayer.logger, type: .info,
-        updatedSchedule.spins.count, updatedSchedule.current.count)
+        updatedSchedule.spins.count, updatedSchedule.current().count)
 
       // Extend the time window to load more upcoming spins (10 minutes instead of 6)
-      let spinsToLoad = updatedSchedule.current.filter { $0.airtime < .now + TimeInterval(600) }
+      let spinsToLoad = updatedSchedule.current().filter { $0.airtime < .now + TimeInterval(600) }
 
       os_log(
         "Loading %d upcoming spins", log: PlayolaStationPlayer.logger, type: .info,
@@ -455,7 +455,7 @@ final public class PlayolaStationPlayer: ObservableObject {
     // Get the schedule
     self.currentSchedule = try await getUpdatedSchedule(stationId: stationId)
 
-    guard let spinToPlay = currentSchedule?.current.first else {
+    guard let spinToPlay = currentSchedule?.current().first else {
       let error = StationPlayerError.scheduleError("No available spins to play")
       Task {
         await errorReporter.reportError(

--- a/Tests/PlayolaPlayerTests/ScheduleTests.swift
+++ b/Tests/PlayolaPlayerTests/ScheduleTests.swift
@@ -78,10 +78,10 @@ struct ScheduleTests {
 
     // Current should only include spins whose endtime is after now
     // The order in current will be the same as in the original array: [currentSpin, futureSpin]
-    #expect(schedule.current.count == 2)
+    #expect(schedule.current().count == 2)
 
     // Verify the correct spins are included without assuming order
-    let currentIds = schedule.current.map { $0.id }
+    let currentIds = schedule.current().map { $0.id }
     #expect(currentIds.contains("current-spin"))
     #expect(currentIds.contains("future-spin"))
     #expect(!currentIds.contains("past-spin"))
@@ -145,7 +145,7 @@ struct ScheduleTests {
     )
 
     // nowPlaying should be the currently playing spin
-    #expect(schedule.nowPlaying?.id == "current-spin")
+    #expect(schedule.nowPlaying()?.id == "current-spin")
 
     // Test with multiple concurrent playing spins
     // Create two overlapping playing spins
@@ -181,7 +181,7 @@ struct ScheduleTests {
     )
 
     // nowPlaying should be the last playing spin in the array
-    #expect(overlappingSchedule.nowPlaying?.id == "playing-2")
+    #expect(overlappingSchedule.nowPlaying()?.id == "playing-2")
   }
 
   @Test("Schedule uses the injected DateProvider")
@@ -209,10 +209,10 @@ struct ScheduleTests {
     )
 
     // With pastProvider (set to 1 minute ago), the spin should be in the future (not ended yet)
-    #expect(!pastSchedule.current.isEmpty)
+    #expect(!pastSchedule.current().isEmpty)
 
     // With futureProvider (set to now), the spin should be in the past (already ended)
-    #expect(futureSchedule.current.isEmpty)
+    #expect(futureSchedule.current().isEmpty)
   }
 
   @Test("Schedule handles empty spins array")
@@ -224,8 +224,8 @@ struct ScheduleTests {
     )
 
     // Verify that empty arrays are handled correctly
-    #expect(emptySchedule.current.isEmpty)
-    #expect(emptySchedule.nowPlaying == nil)
+    #expect(emptySchedule.current().isEmpty)
+    #expect(emptySchedule.nowPlaying() == nil)
   }
 
   @Test("Schedule correctly filters out past spins")
@@ -273,11 +273,11 @@ struct ScheduleTests {
     )
 
     // Current should contain only the spin that hasn't ended yet
-    #expect(schedule.current.count == 1)
-    #expect(schedule.current[0].id == "long-spin")
+    #expect(schedule.current().count == 1)
+    #expect(schedule.current()[0].id == "long-spin")
 
     // nowPlaying should be longSpin since it's the only spin that's currently playing
-    #expect(schedule.nowPlaying?.id == "long-spin")
+    #expect(schedule.nowPlaying()?.id == "long-spin")
   }
 
   @Test("Schedule behavior when no spins are currently playing")
@@ -315,10 +315,10 @@ struct ScheduleTests {
     )
 
     // Current should contain both future spins
-    #expect(futureSchedule.current.count == 2)
+    #expect(futureSchedule.current().count == 2)
 
     // nowPlaying should be nil since no spins are currently playing
-    #expect(futureSchedule.nowPlaying == nil)
+    #expect(futureSchedule.nowPlaying() == nil)
 
     // Create only past spins
     let pastSpin1 = Spin.mockWith(
@@ -349,10 +349,10 @@ struct ScheduleTests {
     )
 
     // Current should contain spins that haven't ended yet
-    #expect(pastSchedule.current.isEmpty)
+    #expect(pastSchedule.current().isEmpty)
 
     // nowPlaying should be nil when no spins are playing
-    #expect(pastSchedule.nowPlaying == nil)
+    #expect(pastSchedule.nowPlaying() == nil)
   }
 
   @Test("Schedule updates nowPlaying when spins change status")
@@ -390,14 +390,14 @@ struct ScheduleTests {
     )
 
     // Initial state - currentSpin should be playing
-    #expect(schedule.nowPlaying?.id == "current")
+    #expect(schedule.nowPlaying()?.id == "current")
 
     // Advance time to when nextSpin starts and execute timer
     dateProviderMock.setMockDate(mockTime.addingTimeInterval(15))
     testTimerProvider.executeNextTimer()
 
     // Now the nextSpin should be playing
-    #expect(schedule.nowPlaying?.id == "next")
+    #expect(schedule.nowPlaying()?.id == "next")
   }
 
   @Test("Schedule properly handles nowPlaying transitions")
@@ -434,22 +434,22 @@ struct ScheduleTests {
     )
 
     // At start (t=0)
-    #expect(schedule.nowPlaying?.id == "spin1")
+    #expect(schedule.nowPlaying()?.id == "spin1")
 
     // Middle of first spin (t=15)
     dateProviderMock.setMockDate(mockTime.addingTimeInterval(15))
     testTimerProvider.executeNextTimer()
-    #expect(schedule.nowPlaying?.id == "spin1")
+    #expect(schedule.nowPlaying()?.id == "spin1")
 
     // At transition (t=30)
     dateProviderMock.setMockDate(mockTime.addingTimeInterval(30))
     testTimerProvider.executeNextTimer()
-    #expect(schedule.nowPlaying?.id == "spin2")
+    #expect(schedule.nowPlaying()?.id == "spin2")
 
     // After all spins (t=70)
     dateProviderMock.setMockDate(mockTime.addingTimeInterval(70))
     testTimerProvider.executeNextTimer()
-    #expect(schedule.nowPlaying == nil)
+    #expect(schedule.nowPlaying() == nil)
   }
 
   @Test("Schedule handles empty spins for nowPlaying")
@@ -459,6 +459,6 @@ struct ScheduleTests {
       spins: []
     )
 
-    #expect(schedule.nowPlaying == nil)
+    #expect(schedule.nowPlaying() == nil)
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to play a station from various time offsets (past or future) and refactors the `Schedule` API to support this functionality. It also updates related tests and adds utility methods to the `Spin` model. The most important changes are grouped below:

**Feature: Offset Playback Controls**
* Adds UI controls in `ContentView.swift` for users to play the station from specific time offsets (e.g., 5 minutes ago, 10 seconds in the future) and introduces a `playWithOffset` function to handle offset-based playback. [[1]](diffhunk://#diff-9a3d086d5a15d737bff94805b77101c62877614328a9fa3a3c3606cebfd08395L138-R180) [[2]](diffhunk://#diff-9a3d086d5a15d737bff94805b77101c62877614328a9fa3a3c3606cebfd08395R378-R414)

**Core Model and API Changes**
* Refactors the `Schedule` model: replaces the `current` property with a `current(offsetTimeInterval:)` method and the `nowPlaying` property with a `nowPlaying(offsetTimeInterval:)` method, both supporting time offsets. Adds a private `adjustedSpins` helper. [[1]](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L18-L27) [[2]](diffhunk://#diff-84e7afbade09a31c1ad7def09ed2b82f6145a42ae83de242f81d7c58650a3473L47-R54)
* Adds a `withOffset(_:)` method to the `Spin` model to create a new spin with an adjusted airtime, supporting offset calculations.
* Makes the `Fade` struct conform to `Equatable` for easier testing and comparisons.

**Player Logic Updates**
* Updates `PlayolaStationPlayer` to support offset playback by introducing a `scheduleOffset` property, modifying the `play` method to accept an `atDate` parameter, and ensuring all schedule lookups respect the offset. [[1]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bR71-R74) [[2]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL308-R318) [[3]](diffhunk://#diff-fea781d41d087c4301bb4dad48ced3bd959c313e683f5e6757d2cbf0b75f810bL443-R471)

**Testing and Maintenance**
* Updates all usages of `Schedule.current` and `Schedule.nowPlaying` in `ScheduleTests.swift` to use the new method-based API, ensuring tests remain accurate and up-to-date. [[1]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L81-R84) [[2]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L148-R148) [[3]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L184-R184) [[4]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L212-R215) [[5]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L227-R228) [[6]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L276-R280) [[7]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L318-R321) [[8]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L352-R355) [[9]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L393-R400) [[10]](diffhunk://#diff-a5797fd08104068e878cd22cbc15241d6ee63a4fe9b190c038ad6c3f3a6dbd84L437-R452)

These changes collectively enable users to start playback from arbitrary points in a station's timeline, improve code flexibility, and maintain robust test coverage.