### PR TITLE
Mock for AudioBlock with spotifyId

### DIFF
--- a/Sources/PlayolaPlayer/Models/AudioBlock.swift
+++ b/Sources/PlayolaPlayer/Models/AudioBlock.swift
@@ -250,6 +250,7 @@ extension AudioBlock {
     popularity: Int? = nil,
     imageUrl: URL? = nil,
     transcription: String? = nil,
+    spotifyId: String? = nil,
     createdAt: Date? = nil,
     updatedAt: Date? = nil
   ) -> AudioBlock {
@@ -276,7 +277,7 @@ extension AudioBlock {
       popularity: popularity ?? mockBlock.popularity,
       youTubeId: mockBlock.youTubeId,
       isrc: mockBlock.isrc,
-      spotifyId: mockBlock.spotifyId,
+      spotifyId: spotifyId ?? mockBlock.spotifyId,
       appleId: mockBlock.appleId,
       imageUrl: imageUrl ?? mockBlock.imageUrl,
       transcription: transcription ?? mockBlock.transcription


### PR DESCRIPTION
This pull request makes a small improvement to the `AudioBlock` model by updating the mock initializer to allow overriding the `spotifyId` property.

* The `mock` initializer in `AudioBlock` now accepts an optional `spotifyId` parameter, enabling explicit setting of this value for test and mock data.
* The assignment logic for `spotifyId` in the initializer has been updated to use the provided value if present, otherwise defaulting to the mock value.